### PR TITLE
Execution of "/" path for command "ls"

### DIFF
--- a/src/github.com/outbrain/zookeepercli/main.go
+++ b/src/github.com/outbrain/zookeepercli/main.go
@@ -64,7 +64,8 @@ func main() {
 		log.Fatal("Expected path argument")
 	}
 	path := flag.Arg(0)
-	if strings.HasSuffix(path, "/") {
+	if *command == "ls" {
+	} else if strings.HasSuffix(path, "/") {
 		log.Fatal("Path must not end with '/'")
 	}
 


### PR DESCRIPTION
Created exception for command string "ls" to pull zookeeper root path keys.