### PR TITLE
improved acl support - ability to set acls on znodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Otherwise the source code is freely available; you will need `git` installed as 
       -acls="31": optional, csv list [1|,2|,4|,8|,16|,31]
       -auth_pwd="": optional, digest scheme, pwd
       -auth_usr="": optional, digest scheme, user
-      -c="": command (exists|get|ls|lsr|create|creater|set|delete|rm|deleter|rmr)
+      -c="": command (exists|get|ls|lsr|create|creater|set|delete|rm|deleter|rmr|getacl|setacl)
       -debug=false: debug mode (very verbose)
       -force=false: force operation
       -format="txt": output format (txt|json)
@@ -113,6 +113,17 @@ Otherwise the source code is freely available; you will need `git` installed as 
     
     # get value using digest authentication
     $ zookeepercli --servers 192.168.59.103 --auth_usr "someuser" --auth_pwd "pass" -c get /secret4
+
+    # view the current acl on a path
+    $ zookeepercli --servers srv-1,srv-2,srv-3 -c create /demo_acl "some value"
+    $ zookeepercli --servers srv-1,srv-2,srv-3 -c getacl /demo_acl
+    world:anyone:cdrwa
+
+    # set an acl with world and digest authentication
+    $ zookeepercli --servers srv-1,srv-2,srv-3 -c setacl /demo_acl "world:anyone:rw,digest:someuser:hashedpw:crdwa"
+    $ zookeepercli --servers srv-1,srv-2,srv-3 -c getacl /demo_acl
+    world:anyone:rw
+    digest:someuser:hashedpw:cdrwa
 
 The tool was built in order to allow with shell scripting seamless integration with ZooKeeper. 
 There is another, official command line tool for ZooKeeper that the author found inadequate 

--- a/src/github.com/outbrain/zookeepercli/zk/zk_test.go
+++ b/src/github.com/outbrain/zookeepercli/zk/zk_test.go
@@ -1,0 +1,73 @@
+/*
+   Copyright 2014 Outbrain Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// zk provides with higher level commands over the lower level zookeeper connector
+package zk
+
+import (
+	"github.com/samuel/go-zookeeper/zk"
+	"testing"
+)
+
+func TestParseACLString(t *testing.T) {
+	cases := []struct {
+		aclstr string
+		want   []zk.ACL
+	}{
+		{"world:anyone:cdrwa", []zk.ACL{{Scheme: "world", ID: "anyone", Perms: 31}}},
+		{"world:anyone:rw", []zk.ACL{{Scheme: "world", ID: "anyone", Perms: 3}}},
+		{"world:anyone:3", []zk.ACL{{Scheme: "world", ID: "anyone", Perms: 3}}},
+		{"host:example.com:cdrw", []zk.ACL{{Scheme: "host", ID: "example.com", Perms: 15}}},
+		{"ip:10.2.1.15/32:cdrwa", []zk.ACL{{Scheme: "ip", ID: "10.2.1.15/32", Perms: 31}}},
+		{"digest:username:pwhash:cd", []zk.ACL{{Scheme: "digest", ID: "username:pwhash", Perms: 12}}},
+		{"auth::cdrwa", []zk.ACL{{Scheme: "auth", ID: "", Perms: 31}}},
+	}
+
+	for _, c := range cases {
+		got, _ := parseACLString(c.aclstr)
+		if !aclsEqual(got, c.want) {
+			t.Errorf("parseACLString(%q) == %q, want %q", c.aclstr, got, c.want)
+		}
+	}
+}
+
+func TestParseInvalidACLString(t *testing.T) {
+	aclstr := "world:anyone:rwb"
+	want := "invalid ACL string specified"
+
+	_, err := parseACLString(aclstr)
+
+	if err == nil {
+		t.Error("No error returned")
+	} else {
+		if err.Error() != want {
+			t.Errorf("parseACLString(%q) error %q, want %q", aclstr, err.Error(), want)
+		}
+	}
+}
+
+func aclsEqual(a, b []zk.ACL) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
This adds the ability to set acls on existing znodes as well as being able to view the current acl on a path. It also supports other acl schemes (not just digest).

Examples:

    zookeepercli --servers $ZK_SERVERS -c create /demo test

    zookeepercli --servers $ZK_SERVERS -c getacl /demo
    world:anyone:cdrwa

    zookeepercli --servers $ZK_SERVERS -c setacl /demo "world:anyone:rw,digest:someuser:somehashedpw:crdwa"

    zookeepercli --servers $ZK_SERVERS -c getacl /demo
    world:anyone:rw
    digest:someuser:somehashedpw:cdrwa

