### PR TITLE
Dockerfile for running zookeepercli in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM gliderlabs/alpine:3.2
+
+MAINTAINER Ryan Eschinger <ryanesc@gmail.com>
+
+COPY . /go/
+
+RUN apk add --update go git \
+  && cd /go/src/github.com/outbrain/zookeepercli/ \
+  && export GOPATH=/go \
+  && go get \
+  && go build -o /bin/zookeepercli \
+  && rm -rf /go \
+  && apk del --purge go git
+
+ENTRYPOINT ["/bin/zookeepercli"]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ in terms of output format and output control, as well as large footprint.
 **zookeepercli** overcomes those limitations and provides with quick, well formatted output as well as
 enhanced functionality. 
 
+### Docker
+
+You can also build and run **zookeepercli** in a Docker container. To build the image:
+
+    $ docker build -t zookeepercli .
+
+Now, you can run **zookeepercli** from a container. Examples:
+
+    $ docker run --rm -it zookeepercli --servers $ZK_SERVERS -c create /docker_demo "test value"
+    $ docker run --rm -it zookeepercli --servers $ZK_SERVERS -c get /docker_demo
+    test value
+    $ docker run --rm -it zookeepercli --servers $ZK_SERVERS -c ls /
+    docker_demo
+    zookeeper
+
 ### License
 
 Release under the [Apache 2.0 license](https://github.com/outbrain/zookeepercli/blob/master/LICENSE)


### PR DESCRIPTION
Ability to run zookeepercli via a Docker container. The Dockerfile generates a small image (~10.5 MB) for running zookeepercli.