### PR TITLE
improved acl support when creating nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Otherwise the source code is freely available; you will need `git` installed as 
     # get value using digest authentication
     $ zookeepercli --servers 192.168.59.103 --auth_usr "someuser" --auth_pwd "pass" -c get /secret4
 
+    # create a value with custom acls
+    $ zookeepercli --servers 192.168.59.103 -c create /secret5 value5 world:anyone:rw,digest:someuser:hashedpw:crdwa
+
     # view the current acl on a path
     $ zookeepercli --servers srv-1,srv-2,srv-3 -c create /demo_acl "some value"
     $ zookeepercli --servers srv-1,srv-2,srv-3 -c getacl /demo_acl
@@ -124,6 +127,9 @@ Otherwise the source code is freely available; you will need `git` installed as 
     $ zookeepercli --servers srv-1,srv-2,srv-3 -c getacl /demo_acl
     world:anyone:rw
     digest:someuser:hashedpw:cdrwa
+
+    # set an acl with world and digest authentication creating the node if it doesn't exist
+    $ zookeepercli --servers srv-1,srv-2,srv-3 -force -c setacl /demo_acl_create "world:anyone:rw,digest:someuser:hashedpw:crdwa"
 
 The tool was built in order to allow with shell scripting seamless integration with ZooKeeper. 
 There is another, official command line tool for ZooKeeper that the author found inadequate 

--- a/src/github.com/outbrain/zookeepercli/main.go
+++ b/src/github.com/outbrain/zookeepercli/main.go
@@ -132,9 +132,16 @@ func main() {
 		}
 	case "create":
 		{
+			var aclstr string
+
 			if len(flag.Args()) < 2 {
 				log.Fatal("Expected data argument")
 			}
+
+			if len(flag.Args()) >= 3 {
+				aclstr = flag.Arg(2)
+			}
+
 			if *authUser != "" && *authPwd != "" {
 				perms, err := zk.BuildACL("digest", *authUser, *authPwd, *acls)
 				if err != nil {
@@ -146,7 +153,7 @@ func main() {
 					log.Fatale(err)
 				}
 			} else {
-				if result, err := zk.Create(path, []byte(flag.Arg(1)), *force); err == nil {
+				if result, err := zk.Create(path, []byte(flag.Arg(1)), aclstr, *force); err == nil {
 					log.Infof("Created %+v", result)
 				} else {
 					log.Fatale(err)
@@ -184,7 +191,7 @@ func main() {
 					log.Fatale(err)
 				}
 			}
-			if result, err := zk.SetACL(path, aclstr); err == nil {
+			if result, err := zk.SetACL(path, aclstr, *force); err == nil {
 				log.Infof("Set %+v", result)
 			} else {
 				log.Fatale(err)


### PR DESCRIPTION
You can set a custom acl when creating a node:

    zookeepercli --servers 192.168.59.103 -c create /secret5 value5 world:anyone:rw,digest:someuser:hashedpw:crdwa

You can also tell the `setacl` command to create the node if it does not exist by passing `-force`.

    zookeepercli --servers srv-1,srv-2,srv-3 -force -c setacl /demo_acl_create "world:anyone:rw,digest:someuser:hashedpw:crdwa"

With this PR, setting a custom digest acl by using `-acl`, `-auth_usr` and `-auth_pwd` is probably not needed anymore. However, I did not remove that code in case people are using it and you want to preserve that interface. If you think this is ok going forward, I'd be glad to clean it up if you'd like; I think it would allow us to remove a few funcs (BuildACL, *WithACL) and simplify the `create` command a bit.

Between this and the last update, I think https://github.com/outbrain/zookeepercli/issues/6 is mostly taken care of. The one thing to note is that there is no way to add / remove individual entries in an ACL. You have to specify the entire ACL when using `setacl` (or `create`).