### PR TITLE
remove tailing "\n" in output

### DIFF
--- a/src/github.com/outbrain/zookeepercli/output/output.go
+++ b/src/github.com/outbrain/zookeepercli/output/output.go
@@ -29,7 +29,7 @@ func PrintString(data []byte, formatType string) {
 	switch formatType {
 	case "txt":
 		{
-			fmt.Println(fmt.Sprintf("%s", data))
+			fmt.Print(fmt.Sprintf("%s", data))
 		}
 	case "json":
 		{


### PR DESCRIPTION
This allows the following pattern:
zookeepercli -c get /abc > file
cat file | zookeepercli -c set /def