### PR TITLE
show go-zookeeper logs only if -verbose provided

### DIFF
--- a/zk/zk.go
+++ b/zk/zk.go
@@ -67,8 +67,15 @@ func BuildACL(authScheme string, user string, pwd string, acls string) (perms []
 	return perms, err
 }
 
+type infoLogger struct{}
+
+func (_ infoLogger) Printf(format string, a ...interface{}) {
+	log.Infof(format, a...)
+}
+
 // connect
 func connect() (*zk.Conn, error) {
+	zk.DefaultLogger = &infoLogger{}
 	conn, _, err := zk.Connect(servers, time.Second)
 	if err == nil && authScheme != "" {
 		log.Debugf("Add Auth %s %s", authScheme, authExpression)


### PR DESCRIPTION
This hides the usual connected/authenticated msgs from go-zookeeper by default.