### PR TITLE
FIX Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gliderlabs/alpine:3.2
 
 MAINTAINER Ryan Eschinger <ryanesc@gmail.com>
 
-COPY . /go/
+COPY . /go/src/github.com/outbrain/zookeepercli/
 
 RUN apk add --update go git \
   && cd /go/src/github.com/outbrain/zookeepercli/ \


### PR DESCRIPTION
Error: /bin/sh: cd: line 1: can't cd to /go/src/github.com/outbrain/zookeepercli/
