### PR TITLE
Fixes #21: lsr with root does not work

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,9 +86,13 @@ func main() {
 		log.Fatal("Expected path argument")
 	}
 	path := flag.Arg(0)
-	if *command == "ls" {
-	} else if strings.HasSuffix(path, "/") {
-		log.Fatal("Path must not end with '/'")
+
+	if strings.HasSuffix(path, "/") {
+		if (*command == "ls" || *command == "lsr") && path == "/" {
+			// ls'ing on / is fine.  Do nothing
+		} else {
+			log.Fatal("Path must not end with '/'")
+		}
 	}
 
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
The code I cut out allowed you to `ls` paths ending with a slash, which meant that you'd just get a `FATAL zk: invalid path` error from zookeeper instead.