### PR TITLE
release_version computed from tag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ set -o pipefail
 #
 
 platform=$(uname -s)
-release_version="1.0.10"
+release_version=$(git describe --abbrev=0 --tags | tr -d 'v')
 release_dir=/tmp/zookeepercli
 rm -rf ${release_dir:?}/*
 mkdir -p $release_dir


### PR DESCRIPTION
Minor fix to build script: generating package names/versions based on `git tag`.