### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/go/zk/zk.go
+++ b/go/zk/zk.go
@@ -62,7 +62,7 @@ func (zook *ZooKeeper) SetAuth(scheme string, auth []byte) {
 	zook.authExpression = auth
 }
 
-// Returns acls
+// BuildACL returns acls
 func (zook *ZooKeeper) BuildACL(authScheme string, user string, pwd string, acls string) (perms []zk.ACL, err error) {
 	aclsList := strings.Split(acls, ",")
 	for _, elem := range aclsList {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?