### PR TITLE
implement geth command

### DIFF
--- a/go/cmd/zookeepercli.go
+++ b/go/cmd/zookeepercli.go
@@ -33,7 +33,7 @@ import (
 // main is the application's entry point.
 func main() {
 	servers := flag.String("servers", "", "srv1[:port1][,srv2[:port2]...]")
-	command := flag.String("c", "", "command, required (exists|get|ls|lsr|create|creater|set|delete|rm|deleter|rmr|getacl|setacl)")
+	command := flag.String("c", "", "command, required (exists|get|geth|ls|lsr|create|creater|set|delete|rm|deleter|rmr|getacl|setacl)")
 	force := flag.Bool("force", false, "force operation")
 	format := flag.String("format", "txt", "output format (txt|json)")
 	omitNewline := flag.Bool("n", false, "omit trailing newline with get in txt format")
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	if len(*command) == 0 {
-		log.Fatal("Expected command (-c) (exists|get|ls|lsr|create|creater|set|delete|rm|deleter|rmr|getacl|setacl)")
+		log.Fatal("Expected command (-c) (exists|get|geth|ls|lsr|create|creater|set|delete|rm|deleter|rmr|getacl|setacl)")
 	}
 
 	if len(flag.Args()) < 1 {
@@ -121,6 +121,14 @@ func main() {
 	case "get":
 		{
 			if result, err := zook.Get(path); err == nil {
+				out.PrintString(result)
+			} else {
+				log.Fatale(err)
+			}
+		}
+	case "geth":
+		{
+			if result, err := zook.GetH(path); err == nil {
 				out.PrintString(result)
 			} else {
 				log.Fatale(err)


### PR DESCRIPTION
I've added new command `geth`. It's looking for a value from path up to root by hierarchy. 

Example: `$ zookeepercli --servers srv-1,srv-2,srv-3 --format=txt -c geth /env/component/subcomponent/key
`

First, it will try to get value `/env/component/subcomponent/key`. In case it's exists `geth` will return it. Otherwise, it goes to upper level and try to search value at `/env/component/key`. In case value is not found it goes to `/env/key` and finally to `/key` if value is not found again. 

The command very useful when application use ZK as hierarchical data storage.